### PR TITLE
fix: Fixes installation of v1 release of Bitwarden Secrets Manager

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -14,16 +14,6 @@ if [ -n "${GITHUB_API_TOKEN:-}" ]; then
 	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
 fi
 
-# curl of REPO/releases/latest is expected to be a 302 to another URL
-# when no releases redirect_url="REPO/releases"
-# when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
-redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
-version=
-printf "redirect url: %s\n" "$redirect_url" >&2
-if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
-	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
-else
-	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/bws-v\{0,1\}||')"
-fi
+version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
 
 printf "%s\n" "$version"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -24,7 +24,7 @@ sort_versions() {
 
 list_github_tags() {
 	git ls-remote --tags --refs "$GH_REPO" |
-		grep -o 'refs/tags/.*' | cut -d/ -f3- |
+		grep -o 'refs/tags/bws-.*' | cut -d/ -f3- |
 		sed 's/^bws-v//' | sed 's/^bws-cli-v//'
 }
 
@@ -53,7 +53,7 @@ get_release_name() {
 	local -r version=$1
 
 	git ls-remote --tags --refs "$GH_REPO" |
-		grep -o 'refs/tags/.*' | cut -d/ -f3- |
+		grep -o 'refs/tags/bws-.*' | cut -d/ -f3- |
 		grep "$version"
 }
 


### PR DESCRIPTION
This PR modifies the installation script for the Bitwarden Secrets Manager to correctly handle the naming of v1 releases. 

1. It no longer tries to use the latest redirect URL since that might point to an unusable release.
2. It adjusts the grep patterns to specifically match tags that start with 'bws-' since other tags now exist which aren't for the CLI.